### PR TITLE
fix: Fix issue with browser build after upgrading `@rollup/plugin-commonjs`

### DIFF
--- a/src/api/pkg-to-configs.ts
+++ b/src/api/pkg-to-configs.ts
@@ -150,6 +150,7 @@ export function pkgToConfigs(
         sourceMap: sourcemap,
         defaultIsModuleExports: true,
         requireReturnsDefault: true,
+        strictRequires: 'auto',
       }),
 
       useTypescript && inputIsTypescript && pluginTypescript({


### PR DESCRIPTION
Browser build fails when trying to bundle `commonjs` module from `node_modules` due to a change in `@rollup/plugin-commonjs`